### PR TITLE
Make external links match Wikipedia external links

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -122,8 +122,7 @@ a.tag, .editor .cl-hashtag {
 }
 
 .external-link {
-  background-image: none;
-  padding-right: unset;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3c?xml version='1.0' encoding='UTF-8'?%3e%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3e%3ctitle%3e external link %3c/title%3e%3cpath fill='%2336c' d='M6 1h5v5L8.86 3.85 4.7 8 4 7.3l4.15-4.16L6 1ZM2 3h2v1H2v6h6V8h1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z'/%3e%3c/svg%3e");
 }
 
 /* footnotes */


### PR DESCRIPTION
## Summary of changes
This PR makes it so that this theme's external links match those of Wikipedia.

## Explanation
External links on Wikipedia include this image:
![external_link](https://github.com/Bluemoondragon07/Wikipedia-Theme/assets/7276621/cfe29b53-2c96-45d1-a88d-0a9e18677906)
(Available here on Wikipedia: [Link to image](https://en.wikipedia.org/w/skins/Vector/resources/common/images/link-external-small-ltr-progressive.svg?30a3a))

Please note this example from the _References_ section of https://en.wikipedia.org/wiki/Box-drawing_character
![image](https://github.com/Bluemoondragon07/Wikipedia-Theme/assets/7276621/b787c3cf-8c11-44d4-9fd1-5de8fd4d1eee)

Of course, if you would prefer to keep this theme looking the way it is now, feel free to ignore this PR!  I already changed the theme to my liking on my own system and figured I'd share it upstream if it's wanted.

Thank you for your time and for the great theme!
