### PR TITLE
Update obsidian.css

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -296,6 +296,9 @@ body {
   word-break: break-all;
 }
 
+.markdown-rendered table {
+    word-break: unset;
+}
 
 /* dataview tables */
 


### PR DESCRIPTION
Added lines 299~301 
```
.markdown-rendered table {
    word-break: unset;
}
```

# Why
Fix advanced-table plugin word-break

---

## Without this section: 
![image](https://github.com/user-attachments/assets/4c08c3d8-c7ff-4c94-bcc4-b1587b2625a3)


## With this section: 
![image](https://github.com/user-attachments/assets/9a4b287f-53ae-4017-9307-26256cc8e7b8)

Credits: @Kapirklaa in Obsidian.md/appearance Discord Channel!